### PR TITLE
support libhdfs3 for secure rpc transfer, inluding all three modes(privacy/integrity/authentication)

### DIFF
--- a/digest-md5/client.c
+++ b/digest-md5/client.c
@@ -57,6 +57,8 @@ struct _Gsasl_digest_md5_client_state
   digest_md5_challenge challenge;
   digest_md5_response response;
   digest_md5_finish finish;
+
+  _Gsasl_digest_md5_encrypt_state encrypt_state;
 };
 typedef struct _Gsasl_digest_md5_client_state _Gsasl_digest_md5_client_state;
 
@@ -85,7 +87,8 @@ _gsasl_digest_md5_client_start (Gsasl_session * sctx, void **mech_data)
 
   state->response.cnonce = p;
   state->response.nc = 1;
-
+  state->response.qop = DIGEST_MD5_QOP_AUTH | DIGEST_MD5_QOP_AUTH_INT | DIGEST_MD5_QOP_AUTH_CONF;
+  state->encrypt_state.cipher = 0;
   *mech_data = state;
 
   return GSASL_OK;
@@ -132,6 +135,7 @@ _gsasl_digest_md5_client_step (Gsasl_session * sctx,
 
 	/* FIXME: cipher, maxbuf. */
 
+    state->response.cipher = choose_cipher(state->challenge.ciphers);
 	/* Create response token. */
 	state->response.utf8 = 1;
 
@@ -140,17 +144,24 @@ _gsasl_digest_md5_client_step (Gsasl_session * sctx,
 
 	{
 	  const char *qop = gsasl_property_get (sctx, GSASL_QOP);
+	  char dummy[2];
 
 	  if (!qop)
-	    state->response.qop = GSASL_QOP_AUTH;
+	    state->response.qop = state->challenge.qops;
 	  else if (strcmp (qop, "qop-int") == 0)
 	    state->response.qop = GSASL_QOP_AUTH_INT;
 	  else if (strcmp (qop, "qop-auth") == 0)
 	    state->response.qop = GSASL_QOP_AUTH;
+	  else if (strcmp (qop, "qop-conf") == 0)
+	    state->response.qop = GSASL_QOP_AUTH_CONF;
 	  else
 	    /* We don't support confidentiality or unknown
 	       keywords. */
 	    return GSASL_AUTHENTICATION_ERROR;
+
+        dummy[0] = state->response.qop;
+        dummy[1] = 0;
+	    gsasl_property_set_raw (sctx, GSASL_QOP, dummy, 1);
 	}
 
 	state->response.nonce = strdup (state->challenge.nonce);
@@ -218,7 +229,6 @@ _gsasl_digest_md5_client_step (Gsasl_session * sctx,
 	  memcpy (state->secret, tmp2, DIGEST_MD5_LENGTH);
 	  free (tmp2);
 	}
-
 	rc = digest_md5_hmac (state->response.response,
 			      state->secret,
 			      state->response.nonce,
@@ -261,8 +271,19 @@ _gsasl_digest_md5_client_step (Gsasl_session * sctx,
 	if (res != GSASL_OK)
 	  break;
 
-	if (strcmp (state->finish.rspauth, check) == 0)
-	  res = GSASL_OK;
+	if (strcmp (state->finish.rspauth, check) == 0) {
+	    res = GSASL_OK;
+	    if (state->response.qop == GSASL_QOP_AUTH_CONF) {
+          memcpy(state->encrypt_state.kcc, state->kcc, DIGEST_MD5_LENGTH);
+          memcpy(state->encrypt_state.kcs, state->kcs, DIGEST_MD5_LENGTH);
+          memcpy(state->encrypt_state.kic, state->kic, DIGEST_MD5_LENGTH);
+          memcpy(state->encrypt_state.kis, state->kis, DIGEST_MD5_LENGTH);
+          state->encrypt_state.cipher = state->response.cipher;
+          state->encrypt_state.client = 1;
+          if (digest_md5_crypt_init(&state->encrypt_state) < 0)
+            res = GSASL_INTEGRITY_ERROR;
+        }
+	 }
 	else
 	  res = GSASL_AUTHENTICATION_ERROR;
 	state->step++;
@@ -289,6 +310,8 @@ _gsasl_digest_md5_client_finish (Gsasl_session * sctx, void *mech_data)
   digest_md5_free_response (&state->response);
   digest_md5_free_finish (&state->finish);
 
+  if (state->encrypt_state.cipher)
+    digest_md5_crypt_cleanup(&state->encrypt_state);
   free (state);
 }
 
@@ -301,8 +324,8 @@ _gsasl_digest_md5_client_encode (Gsasl_session * sctx,
 {
   _Gsasl_digest_md5_client_state *state = mech_data;
   int res;
-
-  res = digest_md5_encode (input, input_len, output, output_len,
+  res = digest_md5_encode (&state->encrypt_state,
+               input, input_len, output, output_len,
 			   state->response.qop,
 			   state->sendseqnum, state->kic);
   if (res)
@@ -326,7 +349,8 @@ _gsasl_digest_md5_client_decode (Gsasl_session * sctx,
   _Gsasl_digest_md5_client_state *state = mech_data;
   int res;
 
-  res = digest_md5_decode (input, input_len, output, output_len,
+  res = digest_md5_decode (&state->encrypt_state,
+               input, input_len, output, output_len,
 			   state->response.qop,
 			   state->readseqnum, state->kis);
   if (res)

--- a/digest-md5/parser.c
+++ b/digest-md5/parser.c
@@ -108,6 +108,29 @@ static const char *const cipher_opts[] = {
   NULL
 };
 
+int choose_cipher(int cipher) {
+    /*
+    Not supported
+
+    if (cipher & DIGEST_MD5_CIPHER_AES_CBC)
+        return DIGEST_MD5_CIPHER_AES_CBC;
+    */
+    if (cipher & DIGEST_MD5_CIPHER_RC4)
+        return DIGEST_MD5_CIPHER_RC4;
+    if (cipher & DIGEST_MD5_CIPHER_3DES)
+        return DIGEST_MD5_CIPHER_3DES;
+    if (cipher & DIGEST_MD5_CIPHER_RC4_56)
+        return DIGEST_MD5_CIPHER_RC4_56;
+    if (cipher & DIGEST_MD5_CIPHER_RC4_40)
+        return DIGEST_MD5_CIPHER_RC4_40;
+    if (cipher & DIGEST_MD5_CIPHER_DES)
+        return DIGEST_MD5_CIPHER_DES;
+    else
+        return 0;
+
+
+}
+
 static int
 parse_challenge (char *challenge, digest_md5_challenge * out)
 {

--- a/digest-md5/parser.h
+++ b/digest-md5/parser.h
@@ -38,4 +38,6 @@ extern int digest_md5_parse_response (const char *response, size_t len,
 extern int digest_md5_parse_finish (const char *finish, size_t len,
 				    digest_md5_finish * out);
 
+int choose_cipher(int ciphers);
+
 #endif /* DIGEST_MD5_PARSER_H */

--- a/digest-md5/server.c
+++ b/digest-md5/server.c
@@ -58,6 +58,8 @@ struct _Gsasl_digest_md5_server_state
   digest_md5_challenge challenge;
   digest_md5_response response;
   digest_md5_finish finish;
+
+  _Gsasl_digest_md5_encrypt_state encrypt_state;
 };
 typedef struct _Gsasl_digest_md5_server_state _Gsasl_digest_md5_server_state;
 
@@ -357,7 +359,8 @@ _gsasl_digest_md5_server_encode (Gsasl_session * sctx,
   _Gsasl_digest_md5_server_state *state = mech_data;
   int res;
 
-  res = digest_md5_encode (input, input_len, output, output_len,
+  res = digest_md5_encode (&state->encrypt_state,
+               input, input_len, output, output_len,
 			   state->response.qop, state->sendseqnum,
 			   state->kis);
   if (res)
@@ -381,7 +384,8 @@ _gsasl_digest_md5_server_decode (Gsasl_session * sctx,
   _Gsasl_digest_md5_server_state *state = mech_data;
   int res;
 
-  res = digest_md5_decode (input, input_len, output, output_len,
+  res = digest_md5_decode (&state->encrypt_state,
+               input, input_len, output, output_len,
 			   state->response.qop, state->readseqnum,
 			   state->kic);
   if (res)

--- a/digest-md5/session.c
+++ b/digest-md5/session.c
@@ -44,8 +44,138 @@
 #define MAC_MSG_TYPE_LEN 2
 #define MAC_SEQNUM_LEN 4
 
+static void slidebits(unsigned char *keybuf, unsigned char *inbuf)
+{
+    keybuf[0] = inbuf[0];
+    keybuf[1] = (inbuf[0]<<7) | (inbuf[1]>>1);
+    keybuf[2] = (inbuf[1]<<6) | (inbuf[2]>>2);
+    keybuf[3] = (inbuf[2]<<5) | (inbuf[3]>>3);
+    keybuf[4] = (inbuf[3]<<4) | (inbuf[4]>>4);
+    keybuf[5] = (inbuf[4]<<3) | (inbuf[5]>>5);
+    keybuf[6] = (inbuf[5]<<2) | (inbuf[6]>>6);
+    keybuf[7] = (inbuf[6]<<1);
+}
+
+int digest_md5_crypt_init(_Gsasl_digest_md5_encrypt_state *state)
+{
+    if (state->cipher != 0) {
+         char *my_key=NULL;
+         char *peer_key=NULL;
+         if (state->client) {
+            my_key = state->kcc;
+            peer_key = state->kcs;
+         } else {
+            my_key = state->kcs;
+            peer_key = state->kcc;
+         }
+         if (state->cipher == DIGEST_MD5_CIPHER_RC4_56) {
+            RC4_set_key(&state->rc4_key_encrypt, DIGEST_MD5_LENGTH, my_key);
+            RC4_set_key(&state->rc4_key_decrypt, DIGEST_MD5_LENGTH, peer_key);
+         } else if (state->cipher == DIGEST_MD5_CIPHER_RC4_40) {
+            RC4_set_key(&state->rc4_key_encrypt, DIGEST_MD5_LENGTH, my_key);
+            RC4_set_key(&state->rc4_key_decrypt, DIGEST_MD5_LENGTH, peer_key);
+         } else if (state->cipher == DIGEST_MD5_CIPHER_RC4) {
+            RC4_set_key(&state->rc4_key_encrypt, DIGEST_MD5_LENGTH, my_key);
+            RC4_set_key(&state->rc4_key_decrypt, DIGEST_MD5_LENGTH, peer_key);
+         } else if (state->cipher == DIGEST_MD5_CIPHER_3DES) {
+            unsigned char keybuf[8];
+            slidebits(keybuf, my_key);
+
+            DES_set_key((const DES_cblock *) keybuf, &state->keysched_encrypt);
+
+            slidebits(keybuf, my_key + 7);
+
+            DES_set_key((const DES_cblock *) keybuf, &state->keysched2_encrypt);
+            memcpy(&state->ivec_encrypt, ((char *) my_key) + 8, 8);
+
+            slidebits(keybuf, peer_key);
+            DES_set_key((const DES_cblock *) keybuf, &state->keysched_decrypt);
+
+            slidebits(keybuf, peer_key + 7);
+
+            DES_set_key((const DES_cblock *) keybuf, &state->keysched2_decrypt);
+
+
+            memcpy(&state->ivec_decrypt, ((char *) peer_key) + 8, 8);
+
+
+         } else if (state->cipher == DIGEST_MD5_CIPHER_DES) {
+
+            unsigned char keybuf[8];
+            slidebits(keybuf, my_key);
+
+            DES_set_key((const DES_cblock *) keybuf, &state->keysched_encrypt);
+
+            memcpy(&state->ivec_encrypt, ((char *) my_key) + 8, 8);
+
+            slidebits(keybuf, peer_key);
+            DES_set_key((const DES_cblock *) keybuf, &state->keysched_decrypt);
+
+            memcpy(&state->ivec_decrypt, ((char *) peer_key) + 8, 8);
+         }
+
+    } else {
+        return 0;
+    }
+}
+
+int digest_md5_crypt_cleanup(_Gsasl_digest_md5_encrypt_state *state) {
+    return 0;
+}
+
+void do_encrypt(_Gsasl_digest_md5_encrypt_state *state, const char* to_encrypt, int encrypt_length, char *encrypted) {
+    if (state->cipher == DIGEST_MD5_CIPHER_RC4_56) {
+        RC4(&state->rc4_key_encrypt, encrypt_length, to_encrypt, encrypted);
+     } else if (state->cipher == DIGEST_MD5_CIPHER_RC4_40) {
+        RC4(&state->rc4_key_encrypt, encrypt_length, to_encrypt, encrypted);
+     } else if (state->cipher == DIGEST_MD5_CIPHER_RC4) {
+        RC4(&state->rc4_key_encrypt, encrypt_length, to_encrypt, encrypted);
+     } else if (state->cipher == DIGEST_MD5_CIPHER_3DES) {
+            DES_ede2_cbc_encrypt(to_encrypt,
+			 encrypted,
+			 encrypt_length,
+			 &state->keysched_encrypt,
+			 &state->keysched2_encrypt,
+			 &state->ivec_encrypt,
+			 DES_ENCRYPT);
+     } else if (state->cipher == DIGEST_MD5_CIPHER_DES) {
+            DES_ncbc_encrypt(to_encrypt,
+                    encrypted,
+                    encrypt_length,
+                    &state->keysched_encrypt,
+                    &state->ivec_encrypt,
+                    DES_ENCRYPT);
+     }
+}
+
+void do_decrypt(_Gsasl_digest_md5_encrypt_state *state, const char* to_decrypt, int decrypt_length, char *decrypted) {
+    if (state->cipher == DIGEST_MD5_CIPHER_RC4_56) {
+        RC4(&state->rc4_key_decrypt, decrypt_length, to_decrypt, decrypted);
+     } else if (state->cipher == DIGEST_MD5_CIPHER_RC4_40) {
+        RC4(&state->rc4_key_decrypt, decrypt_length, to_decrypt, decrypted);
+     } else if (state->cipher == DIGEST_MD5_CIPHER_RC4) {
+        RC4(&state->rc4_key_decrypt, decrypt_length, to_decrypt, decrypted);
+     } else if (state->cipher == DIGEST_MD5_CIPHER_3DES) {
+        DES_ede2_cbc_encrypt(to_decrypt,
+			 decrypted,
+			 decrypt_length,
+			 &state->keysched_decrypt,
+			 &state->keysched2_decrypt,
+			 &state->ivec_decrypt,
+			 DES_DECRYPT);
+     } else if (state->cipher == DIGEST_MD5_CIPHER_DES) {
+        DES_ncbc_encrypt(to_decrypt,
+                    decrypted,
+                    decrypt_length,
+                    &state->keysched_decrypt,
+                    &state->ivec_decrypt,
+                    DES_DECRYPT);
+     }
+}
+
 int
-digest_md5_encode (const char *input, size_t input_len,
+digest_md5_encode (_Gsasl_digest_md5_encrypt_state *state,
+           const char *input, size_t input_len,
 		   char **output, size_t * output_len,
 		   digest_md5_qop qop,
 		   unsigned long sendseqnum, char key[DIGEST_MD5_LENGTH])
@@ -54,7 +184,82 @@ digest_md5_encode (const char *input, size_t input_len,
 
   if (qop & DIGEST_MD5_QOP_AUTH_CONF)
     {
-      return -1;
+      char *seqnumin;
+      char hash[GC_MD5_DIGEST_SIZE];
+      char pad[19]; // block size for rc4 is 1, and 8 for DES/3DES
+      int padding = 0;
+      int encrypt_length;
+      size_t len;
+      char *to_encrypt;
+      char *encrypted;
+      char *my_key=NULL;
+      if (!state->cipher)
+          return -1;
+
+      seqnumin = malloc (MAC_SEQNUM_LEN + input_len);
+      if (seqnumin == NULL)
+	    return -1;
+
+      seqnumin[0] = (sendseqnum >> 24) & 0xFF;
+      seqnumin[1] = (sendseqnum >> 16) & 0xFF;
+      seqnumin[2] = (sendseqnum >> 8) & 0xFF;
+      seqnumin[3] = sendseqnum & 0xFF;
+      memcpy (seqnumin + MAC_SEQNUM_LEN, input, input_len);
+
+      if (state->client)
+         my_key = state->kic;
+      else
+        my_key = state->kis;
+      res = gc_hmac_md5 (my_key, MD5LEN,
+			 seqnumin, MAC_SEQNUM_LEN + input_len, hash);
+      free (seqnumin);
+      if (res)
+	    return -1;
+
+      if (state->cipher == DIGEST_MD5_CIPHER_3DES || state->cipher == DIGEST_MD5_CIPHER_DES) {
+        int i;
+        padding = 8 - ((input_len+MAC_HMAC_LEN) % 8);
+        for (i=0; i < padding; i++)
+            pad[i] = padding;
+      }
+      to_encrypt = malloc(input_len+padding+MAC_HMAC_LEN);
+      if (to_encrypt == NULL)
+    	return -1;
+      encrypted = malloc(input_len+padding+MAC_HMAC_LEN);
+      if (encrypted == NULL) {
+        free(to_encrypt);
+    	return -1;
+      }
+      memcpy(to_encrypt, input, input_len);
+      memcpy(to_encrypt+input_len, pad, padding);
+      memcpy(to_encrypt+input_len+padding, hash, MAC_HMAC_LEN);
+      encrypt_length = input_len+padding + MAC_HMAC_LEN;
+      do_encrypt(state, to_encrypt, encrypt_length, encrypted);
+      // Do encrypt
+      free(to_encrypt);
+
+	  *output_len = MAC_DATA_LEN + encrypt_length  +
+	    MAC_MSG_TYPE_LEN + MAC_SEQNUM_LEN;
+	  *output = malloc (*output_len);
+      if (!*output) {
+        free(encrypted);
+	    return -1;
+      }
+      len = MAC_DATA_LEN;
+      memcpy (*output + len, encrypted, encrypt_length);
+      free(encrypted);
+      len += encrypt_length;
+      memcpy (*output + len, MAC_MSG_TYPE, MAC_MSG_TYPE_LEN);
+      len += MAC_MSG_TYPE_LEN;
+      (*output + len)[0] = (sendseqnum >> 24) & 0xFF;
+      (*output + len)[1] = (sendseqnum >> 16) & 0xFF;
+      (*output + len)[2] = (sendseqnum >> 8) & 0xFF;
+      (*output + len)[3] = sendseqnum & 0xFF;
+      len += MAC_SEQNUM_LEN;
+      (*output)[0] = ((len - MAC_DATA_LEN) >> 24) & 0xFF;
+      (*output)[1] = ((len - MAC_DATA_LEN) >> 16) & 0xFF;
+      (*output)[2] = ((len - MAC_DATA_LEN) >> 8) & 0xFF;
+      (*output)[3] = (len - MAC_DATA_LEN) & 0xFF;
     }
   else if (qop & DIGEST_MD5_QOP_AUTH_INT)
     {
@@ -119,14 +324,102 @@ digest_md5_encode (const char *input, size_t input_len,
 		  ((buf[0] & 0xFF) << 24))
 
 int
-digest_md5_decode (const char *input, size_t input_len,
+digest_md5_decode (_Gsasl_digest_md5_encrypt_state *state,
+           const char *input, size_t input_len,
 		   char **output, size_t * output_len,
 		   digest_md5_qop qop,
 		   unsigned long readseqnum, char key[DIGEST_MD5_LENGTH])
 {
   if (qop & DIGEST_MD5_QOP_AUTH_CONF)
     {
-      return -1;
+      char *seqnumin;
+      char hash[GC_MD5_DIGEST_SIZE];
+      unsigned long len;
+      char tmpbuf[SASL_INTEGRITY_PREFIX_LENGTH];
+      char msgType[MAC_MSG_TYPE_LEN];
+      char seqNum[MAC_SEQNUM_LEN];
+      char originalHash[GC_MD5_DIGEST_SIZE];
+      char *encrypted;
+      char *decrypted;
+      int encrypted_length;
+      int res;
+      char *my_key=NULL;
+      if (!state->cipher)
+          return -1;
+
+      if (input_len < SASL_INTEGRITY_PREFIX_LENGTH)
+    	return -2;
+
+      len = C2I (input);
+
+      if (input_len < SASL_INTEGRITY_PREFIX_LENGTH + len)
+	    return -2;
+
+      if (state->client)
+         my_key = state->kis;
+      else
+         my_key = state->kic;
+      memcpy(msgType, input+input_len-MAC_SEQNUM_LEN-MAC_MSG_TYPE_LEN, MAC_MSG_TYPE_LEN);
+      memcpy(seqNum, input+input_len-MAC_SEQNUM_LEN, MAC_SEQNUM_LEN);
+
+      encrypted_length = input_len - MAC_MSG_TYPE_LEN - MAC_SEQNUM_LEN - MAC_DATA_LEN;
+      encrypted = malloc(encrypted_length);
+      if (encrypted == NULL)
+        return -1;
+      decrypted = malloc(encrypted_length);
+      if (decrypted == NULL) {
+        free(encrypted);
+        return -1;
+      }
+      memcpy(encrypted, input+MAC_DATA_LEN, encrypted_length);
+
+      do_decrypt(state, encrypted, encrypted_length, decrypted);
+      free(encrypted);
+      memcpy(originalHash, decrypted+encrypted_length-MAC_HMAC_LEN, MAC_HMAC_LEN);
+      encrypted_length -= MAC_HMAC_LEN;
+      if (state->cipher == DIGEST_MD5_CIPHER_3DES || state->cipher == DIGEST_MD5_CIPHER_DES) {
+        encrypted_length -= decrypted[encrypted_length-1];
+      }
+
+      seqnumin = malloc (MAC_SEQNUM_LEN + encrypted_length);
+      if (seqnumin == NULL) {
+        free(decrypted);
+	    return -1;
+      }
+      tmpbuf[0] = (readseqnum >> 24) & 0xFF;
+      tmpbuf[1] = (readseqnum >> 16) & 0xFF;
+      tmpbuf[2] = (readseqnum >> 8) & 0xFF;
+      tmpbuf[3] = readseqnum & 0xFF;
+
+      memcpy (seqnumin, tmpbuf, MAC_SEQNUM_LEN);
+      memcpy (seqnumin + MAC_SEQNUM_LEN,
+	      decrypted, encrypted_length);
+
+      res = gc_hmac_md5 (my_key, MD5LEN, seqnumin, MAC_SEQNUM_LEN + encrypted_length, hash);
+      free (seqnumin);
+      if (res) {
+        free(decrypted);
+	    return -1;
+      }
+      if (memcmp(hash, originalHash, MAC_HMAC_LEN) == 0
+	  && memcmp (MAC_MSG_TYPE,
+		     msgType,
+		     MAC_MSG_TYPE_LEN) == 0
+	  && memcmp (tmpbuf, seqNum,
+		     MAC_SEQNUM_LEN) == 0)
+	{
+	  *output_len = encrypted_length;
+	  *output = malloc (*output_len);
+	  if (!*output) {
+	    free(decrypted);
+	    return -1;
+	  }
+	  memcpy (*output, decrypted, encrypted_length);
+	}
+    else {
+        free(decrypted);
+	    return -1;
+	 }
     }
   else if (qop & DIGEST_MD5_QOP_AUTH_INT)
     {

--- a/digest-md5/session.h
+++ b/digest-md5/session.h
@@ -26,13 +26,45 @@
 /* Get token types. */
 #include "tokens.h"
 
-extern int digest_md5_encode (const char *input, size_t input_len,
+#include <openssl/des.h>
+#include <openssl/opensslv.h>
+#include <openssl/rc4.h>
+
+struct _Gsasl_digest_md5_encrypt_state
+{
+  char kic[DIGEST_MD5_LENGTH];
+  char kis[DIGEST_MD5_LENGTH];
+  char kcc[DIGEST_MD5_LENGTH];
+  char kcs[DIGEST_MD5_LENGTH];
+  int cipher;
+  int client;
+
+  RC4_KEY rc4_key_encrypt;
+  RC4_KEY rc4_key_decrypt;
+
+  DES_key_schedule keysched_encrypt;  /* key schedule for des initialization */
+  DES_cblock ivec_encrypt;            /* initial vector for encoding */
+  DES_key_schedule keysched2_encrypt; /* key schedule for 3des initialization */
+
+  DES_key_schedule keysched_decrypt;  /* key schedule for des initialization */
+  DES_cblock ivec_decrypt;            /* initial vector for encoding */
+  DES_key_schedule keysched2_decrypt; /* key schedule for 3des initialization */
+};
+
+typedef struct _Gsasl_digest_md5_encrypt_state _Gsasl_digest_md5_encrypt_state;
+
+extern int digest_md5_crypt_init(_Gsasl_digest_md5_encrypt_state *state);
+extern int digest_md5_crypt_cleanup(_Gsasl_digest_md5_encrypt_state *state);
+
+extern int digest_md5_encode (_Gsasl_digest_md5_encrypt_state *state,
+                  const char *input, size_t input_len,
 			      char **output, size_t * output_len,
 			      digest_md5_qop qop,
 			      unsigned long sendseqnum,
 			      char key[DIGEST_MD5_LENGTH]);
 
-extern int digest_md5_decode (const char *input, size_t input_len,
+extern int digest_md5_decode (_Gsasl_digest_md5_encrypt_state *state,
+                  const char *input, size_t input_len,
 			      char **output, size_t * output_len,
 			      digest_md5_qop qop,
 			      unsigned long readseqnum,

--- a/gssapi/client.c
+++ b/gssapi/client.c
@@ -64,7 +64,7 @@ _gsasl_gssapi_client_start (Gsasl_session * sctx, void **mech_data)
   state->context = GSS_C_NO_CONTEXT;
   state->service = GSS_C_NO_NAME;
   state->step = 0;
-  state->qop = GSASL_QOP_AUTH;	/* FIXME: Should be GSASL_QOP_AUTH_CONF. */
+  state->qop = GSASL_QOP_AUTH | GSASL_QOP_AUTH_CONF | GSASL_QOP_AUTH_INT;
 
   *mech_data = state;
 
@@ -86,10 +86,11 @@ _gsasl_gssapi_client_step (Gsasl_session * sctx,
   int conf_state;
   int res;
   const char *p;
+  int qop = 0;
 
   if (state->service == NULL)
     {
-      const char *service, *hostname;
+      const char *service, *hostname, *principal;
 
       service = gsasl_property_get (sctx, GSASL_SERVICE);
       if (!service)
@@ -99,21 +100,38 @@ _gsasl_gssapi_client_step (Gsasl_session * sctx,
       if (!hostname)
 	return GSASL_NO_HOSTNAME;
 
+	  principal = gsasl_property_get (sctx, GSASL_GSSAPI_DISPLAY_NAME);
       /* FIXME: Use asprintf. */
+      if (!principal) {
 
-      bufdesc.length = strlen (service) + 1 + strlen (hostname) + 1;
-      bufdesc.value = malloc (bufdesc.length);
-      if (bufdesc.value == NULL)
-	return GSASL_MALLOC_ERROR;
+          bufdesc.length = strlen (service) + 1 + strlen (hostname) + 1;
+          bufdesc.value = malloc (bufdesc.length);
+          if (bufdesc.value == NULL)
+                return GSASL_MALLOC_ERROR;
 
-      sprintf (bufdesc.value, "%s@%s", service, hostname);
+          sprintf (bufdesc.value, "%s@%s", service, hostname);
 
-      maj_stat = gss_import_name (&min_stat, &bufdesc,
-				  GSS_C_NT_HOSTBASED_SERVICE,
-				  &state->service);
-      free (bufdesc.value);
-      if (GSS_ERROR (maj_stat))
-	return GSASL_GSSAPI_IMPORT_NAME_ERROR;
+          maj_stat = gss_import_name (&min_stat, &bufdesc,
+                      GSS_C_NT_HOSTBASED_SERVICE,
+                      &state->service);
+          free (bufdesc.value);
+          if (GSS_ERROR (maj_stat))
+               return GSASL_GSSAPI_IMPORT_NAME_ERROR;
+     } else {
+          bufdesc.length = strlen (principal) + 1;
+          bufdesc.value = malloc (bufdesc.length);
+          if (bufdesc.value == NULL)
+                return GSASL_MALLOC_ERROR;
+
+          sprintf (bufdesc.value, "%s", principal);
+
+          maj_stat = gss_import_name (&min_stat, &bufdesc,
+                      GSS_C_NT_USER_NAME,
+                      &state->service);
+          free (bufdesc.value);
+          if (GSS_ERROR (maj_stat))
+               return GSASL_GSSAPI_IMPORT_NAME_ERROR;
+     }
     }
 
   switch (state->step)
@@ -181,6 +199,7 @@ _gsasl_gssapi_client_step (Gsasl_session * sctx,
       bufdesc.value = (void *) input;
       maj_stat = gss_unwrap (&min_stat, state->context, &bufdesc,
 			     &bufdesc2, &conf_state, &serverqop);
+
       if (GSS_ERROR (maj_stat))
 	return GSASL_GSSAPI_UNWRAP_ERROR;
 
@@ -188,6 +207,7 @@ _gsasl_gssapi_client_step (Gsasl_session * sctx,
 	return GSASL_MECHANISM_PARSE_ERROR;
 
       memcpy (clientwrap, bufdesc2.value, 4);
+      qop = (int) ((char*)bufdesc2.value)[0];
 
       maj_stat = gss_release_buffer (&min_stat, &bufdesc2);
       if (GSS_ERROR (maj_stat))
@@ -215,7 +235,9 @@ _gsasl_gssapi_client_step (Gsasl_session * sctx,
 	return GSASL_MALLOC_ERROR;
 
       {
+
 	char *q = bufdesc.value;
+	state->qop = qop;
 	q[0] = state->qop;
 	memcpy (q + 1, clientwrap + 1, 3);
 	memcpy (q + 4, p, strlen (p));
@@ -282,7 +304,6 @@ _gsasl_gssapi_client_encode (Gsasl_session * sctx,
 
   foo.length = input_len;
   foo.value = (void *) input;
-
   if (state && state->step == 3 &&
       state->qop & (GSASL_QOP_AUTH_INT | GSASL_QOP_AUTH_CONF))
     {
@@ -295,7 +316,7 @@ _gsasl_gssapi_client_encode (Gsasl_session * sctx,
       if (GSS_ERROR (maj_stat))
 	return GSASL_GSSAPI_WRAP_ERROR;
       *output_len = output_message_buffer.length;
-      *output = malloc (input_len);
+      *output = malloc (*output_len);
       if (!*output)
 	{
 	  maj_stat = gss_release_buffer (&min_stat, &output_message_buffer);
@@ -348,7 +369,7 @@ _gsasl_gssapi_client_decode (Gsasl_session * sctx,
       if (GSS_ERROR (maj_stat))
 	return GSASL_GSSAPI_UNWRAP_ERROR;
       *output_len = output_message_buffer.length;
-      *output = malloc (input_len);
+      *output = malloc (*output_len);
       if (!*output)
 	{
 	  maj_stat = gss_release_buffer (&min_stat, &output_message_buffer);


### PR DESCRIPTION
Changelog category:
New Feature

Changelog entry:
Quality of Protection (QOP) extends to support three modes(QOP_AUTH/QOP_AUTH_INT/QOP_AUTH_CONF) of the DIGEST-MD5 and GSSAPI mechanisms. This PR is part of supportting libhdfs3 for secure rpc transfer.

Currenty, Clickhouse doesn't support hadoop.rpc.protection=privacy or hadoop.rpc.protection=integrity.  There're 3 parts need to modify. This is the first part. 
The second PR refer: 
https://github.com/ClickHouse/libhdfs3/pull/21
And the third PR refer:
https://github.com/ClickHouse/ClickHouse/pull/37852