### PR TITLE
Changes to support the HDFS in PowerPC

### DIFF
--- a/gl/float.c
+++ b/gl/float.c
@@ -20,13 +20,12 @@
 /* Specification.  */
 #include <float.h>
 
+#if (defined _ARCH_PPC || defined _POWER) && (defined _AIX || defined __linux__) && (LDBL_MANT_DIG == 106) && defined __GNUC__
 union gl_long_double_union
    {
      struct { double hi; double lo; } dd;
      long double ld;
    };
-
-#if (defined _ARCH_PPC || defined _POWER) && (defined _AIX || defined __linux__) && (LDBL_MANT_DIG == 106) && defined __GNUC__
 const union gl_long_double_union gl_LDBL_MAX =
   { { DBL_MAX, DBL_MAX / (double)134217728UL / (double)134217728UL } };
 #elif defined __i386__

--- a/gl/float.c
+++ b/gl/float.c
@@ -20,6 +20,12 @@
 /* Specification.  */
 #include <float.h>
 
+union gl_long_double_union
+   {
+     struct { double hi; double lo; } dd;
+     long double ld;
+   };
+
 #if (defined _ARCH_PPC || defined _POWER) && (defined _AIX || defined __linux__) && (LDBL_MANT_DIG == 106) && defined __GNUC__
 const union gl_long_double_union gl_LDBL_MAX =
   { { DBL_MAX, DBL_MAX / (double)134217728UL / (double)134217728UL } };


### PR DESCRIPTION
Enable the HDFS support in PowerPC and which helps to fixes the following functional tests 02113_hdfs_assert.sh, 02244_hdfs_cluster.sql and 02368_cancel_write_into_hdfs.sh.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95450